### PR TITLE
Fix transition matrix normalization and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ left_right = create_transition_matrix(5, "left_to_right")         # 순차 진�
 skip_matrix = create_transition_matrix(5, "left_to_right_skip")   # 상태 건너뛰기 허용
 circular = create_transition_matrix(5, "circular")               # 순환 구조
 ```
+생성된 전이 행렬은 각 행이 1로 정규화된 확률 분포입니다.
 
 ### 2. 가우시안 HMM (연속 특징용)
 

--- a/pytorch_hmm/hmm.py
+++ b/pytorch_hmm/hmm.py
@@ -108,10 +108,10 @@ class HMMPyTorch(HMM):
         
         # Backward recursion  
         for t in range(T-2, -1, -1):
-            # self.log_P[:, :, None] + log_obs[:, t+1, None, :] + log_backward[:, t+1, None, :]
-            # Shape: (K, K, 1) + (B, 1, K) + (B, 1, K) = (B, K, K)
-            combined = (self.log_P[:, :, None] + 
-                       log_obs[:, t+1, None, :] + 
+            # self.log_P broadcast to batch dimension
+            # Shape: (1, K, K) + (B, 1, K) + (B, 1, K) = (B, K, K)
+            combined = (self.log_P[None, :, :] +
+                       log_obs[:, t+1, None, :] +
                        log_backward[:, t+1, None, :])
             
             log_backward[:, t] = torch.logsumexp(combined, dim=2)

--- a/pytorch_hmm/utils.py
+++ b/pytorch_hmm/utils.py
@@ -27,7 +27,8 @@ def create_transition_matrix(num_states: int,
         device: 텐서 device
         
     Returns:
-        Transition matrix of shape (num_states, num_states)
+        Transition matrix of shape (num_states, num_states). 각 행은 1로 정규화
+        되어 반환됩니다.
     """
     P = torch.zeros(num_states, num_states, device=device)
     
@@ -69,7 +70,10 @@ def create_transition_matrix(num_states: int,
         raise ValueError(f"Unknown transition_type: {transition_type}")
     
     # 행별로 정규화하여 확률 분포로 만들기
-    P = P / P.sum(dim=1, keepdim=True)
+    # 0으로만 채워진 행이 있을 경우 division-by-zero를 피하기 위해 epsilon을 더함
+    row_sums = P.sum(dim=1, keepdim=True)
+    row_sums = row_sums + (row_sums == 0).float() * 1e-8
+    P = P / row_sums
     
     return P
 

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -281,6 +281,12 @@ class TestUtilityFunctions:
             assert P.shape == (num_states, num_states)
             assert torch.allclose(P.sum(dim=1), torch.ones(num_states))
             assert torch.all(P >= 0)
+
+    def test_transition_matrix_row_normalization(self):
+        """행별 합이 1인지 확인"""
+        num_states = 3
+        P = create_transition_matrix(num_states, transition_type="ergodic")
+        assert torch.allclose(P.sum(dim=1), torch.ones(num_states))
     
     def test_compute_state_durations(self):
         """상태 지속시간 계산 테스트"""


### PR DESCRIPTION
## Reason for the change
- `create_transition_matrix` normalized rows but could produce division by zero for empty rows. Documentation didn't state that rows sum to one. Some tests also failed because of a broadcasting error in the backward pass.

## Description of the change
- Added epsilon-protected row normalization in `utils.create_transition_matrix` and documented the guarantee in the docstring and README.
- Corrected broadcasting in `HMMPyTorch.forward_backward` to handle batched input.
- Added a new unit test checking row normalization.
- Updated comments accordingly.


------
https://chatgpt.com/codex/tasks/task_e_6853f4e7cdf483288397db3f9e03908d